### PR TITLE
Add dependency install setup step

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,16 @@ the components in convenient way.
 git clone https://github.com/phema/phema-workbench-app.git && cd phema-workbench-app
 ```
 
-> #### 2. Run Parcel
+> #### 2. Install dependencies
+
+Running the following will ensure all packages and dependencies are installed.
+
+```
+yarn
+```
+
+
+> #### 3. Run Parcel
 
 Running the following will start Parcel in `serve` mode, which will
 automatically rebuild when you make any changes:
@@ -75,7 +84,7 @@ automatically rebuild when you make any changes:
 yarn start
 ```
 
-> #### 3. Build Release
+> #### 4. Build Release
 
 When you're done making your changes, you can run a release build:
 


### PR DESCRIPTION
This was needed for me to get running locally.  Even though I had parcel and other dependencies (seemingly) installed, I was getting  an error:

```
$ yarn start
yarn run v1.19.1
$ yarn run build:worker && parcel serve --port 8989 --log-level verbose --no-cache ./index.html
$ parcel build --no-scope-hoist ../../node_modules/monaco-editor/esm/vs/editor/editor.worker.js --no-source-maps
error: unknown option `--no-scope-hoist'
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```